### PR TITLE
Fix encoding problems

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -5,6 +5,8 @@ import collections
 import numpy as np
 import tensorflow as tf
 
+from functools import partial
+
 OOV_ID = -1
 
 
@@ -76,7 +78,8 @@ class Word2VecDataset(object):
       raw_vocab: a list of 2-tuples holding the word (string) and count (int),
         sorted in descending order of word count. 
     """
-    lines = itertools.chain(*map(open, filenames))
+    map_open = partial(open, encoding="utf-8")
+    lines = itertools.chain(*map(map_open, filenames))
     raw_vocab = collections.Counter()
     for line in lines:
       raw_vocab.update(line.strip().split())

--- a/run_training.py
+++ b/run_training.py
@@ -99,7 +99,7 @@ def main(_):
     syn0_final = sess.run(word2vec.syn0)
 
   np.save(os.path.join(FLAGS.out_dir, 'embed'), syn0_final)
-  with open(os.path.join(FLAGS.out_dir, 'vocab.txt'), 'w') as fid:
+  with open(os.path.join(FLAGS.out_dir, 'vocab.txt'), 'w', encoding="utf-8") as fid:
     for w in dataset.table_words:
       fid.write(w + '\n')
   print('Word embeddings saved to', os.path.join(FLAGS.out_dir, 'embed.npy'))


### PR DESCRIPTION
There was a problem, where the words that contained non-ASCII characters, were entirely separated in the embedding space after embedding. Using UTF-8 encoding fixes this problem.

Changes:
Use UTF-8 encoding when reading in the files
Use UTF-8 encoding when writing out vocab